### PR TITLE
always send LaunchResponse after successful initialization

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -127,17 +127,11 @@ class Main extends vscode.debugAdapter.DebugSession {
 
 			socket.on(SocketEvent.Error, error -> trace('Socket error: $error'));
 
-			function ready() {
-				sendEvent(new vscode.debugAdapter.DebugSession.InitializedEvent());
-			}
-
 			executePostLaunchActions(function() {
+				sendEvent(new vscode.debugAdapter.DebugSession.InitializedEvent());
+				sendResponse(response);
 				if (args.stopOnEntry) {
-					ready();
-					sendResponse(response);
 					sendEvent(new vscode.debugAdapter.DebugSession.StoppedEvent("entry", 0));
-				} else {
-					ready();
 				}
 			});
 		}


### PR DESCRIPTION
Currently the LaunchResponse is only send if stopOnEntry is `true`. This results in hanging connection if stopOnEntry is `false`, as the client is waiting for the LaunchResponse